### PR TITLE
fix: force consent via prompt property

### DIFF
--- a/server.js
+++ b/server.js
@@ -156,6 +156,9 @@ fastify.get('/auth/google', function (req, reply) {
     state: state,
     // Enable incremental authorization. Recommended as a best practice.
     include_granted_scopes: true,
+    // Setting the prompt to 'consent' will force this consent
+    // every time, forcing a refresh_token to be returned.
+    prompt: 'consent',
   });
 
   return reply.redirect(301, authorizationUrl);


### PR DESCRIPTION
**Summary**
By setting the prompt property, user will always see the Google sign-in page. See https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#obtaining-a-new-refresh-token .